### PR TITLE
Make GitHub repo pull friendly for Windows users

### DIFF
--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,4 @@
+#Ignore all files in this directory
+*
+# Except me
+!.gitignore


### PR DESCRIPTION
This allows ShowMarks to be used immediately after pulling from github
since (at least for Windows) ShowMarks complains if the doc folder is
missing. Intentionally not fixing the script itself so that git hub remains an exact copy of the original.

Without this patch, a Windows user will see this error message if they open vim with this plugin installed after pulling from GitHub: Error detected while processing C:\Users\YourUserName\vimfiles\bundle\git-showMarks\plugin\showmarks.vim:line  513

Signed-off-by: Greg Dietsche Gregory.Dietsche@cuw.edu
