### PR TITLE
Don't show errors on recent VIM versions.

### DIFF
--- a/plugin/showmarks.vim
+++ b/plugin/showmarks.vim
@@ -374,7 +374,9 @@ fun! s:ShowMarks()
 				let mark_at{ln} = nm
 				if !exists('b:placed_'.nm) || b:placed_{nm} != ln
 					exe 'sign unplace '.id.' buffer='.winbufnr(0)
-					exe 'sign place '.id.' name=ShowMark'.nm.' line='.ln.' buffer='.winbufnr(0)
+					if ln > 0 " conditional which tests for the line number as greater than 0 "
+						exe 'sign place '.id.' name=ShowMark'.nm.' line='.ln.' buffer='.winbufnr(0)
+					endif     " end conditional "
 					let b:placed_{nm} = ln
 				endif
 			endif


### PR DESCRIPTION
VIM 7.4 patch 258.1 broke some ShowMarks, it displays the following
error a lot:

E885: Not possible to change sign ShowMark72

Fix taken from this Google Groups discussion:
https://groups.google.com/forum/#!topic/vim_use/i_FRMtA5R60